### PR TITLE
Update Dockerfile to use cp-kafka:4.1.0

### DIFF
--- a/kafka/Dockerfile
+++ b/kafka/Dockerfile
@@ -1,4 +1,4 @@
-FROM confluentinc/cp-kafka
+FROM confluentinc/cp-kafka:4.1.0
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \


### PR DESCRIPTION
To update base tech Kafka to 1.1.0 we need to update the kafka-client to
4.1.0. This fixes the auth errors we saw in CI during the upgrade.